### PR TITLE
Make sure closing date gets saved only if it has a value

### DIFF
--- a/actions/poll/edit.php
+++ b/actions/poll/edit.php
@@ -95,7 +95,7 @@ $poll->question = $question;
 $poll->title = $question;
 $poll->description = $description;
 $poll->open_poll = $open_poll ? 1 : 0;
-$poll->close_date = $close_date;
+$poll->close_date = empty($close_date) ? null : $close_date;
 $poll->tags = string_to_tag_array($tags);
 
 if (!$poll->save()) {


### PR DESCRIPTION
I don't understand how I managed to test this successfully when doing 08960159b8a75772ee34473483615bda1724bc1e. It's still saving en empty string.

Anyway, now it's impossible to accidentally save a numeric zero or an empty string as the date value.